### PR TITLE
Multiple uid search

### DIFF
--- a/lib/Adapter.php
+++ b/lib/Adapter.php
@@ -26,10 +26,10 @@ abstract class sspmod_perun_Adapter
 
 	/**
 	 * @param string $idpEntityId entity id of hosted idp used as extSourceName
-	 * @param string $uid user identifier received from remote idp used as userExtSourceLogin
+	 * @param string $uids list of user identifiers received from remote idp used as userExtSourceLogin
 	 * @return sspmod_perun_model_User or null if not exists
 	 */
-	public abstract function getPerunUser($idpEntityId, $uid);
+	public abstract function getPerunUser($idpEntityId, $uids);
 
 	/**
 	 * @param sspmod_perun_model_Vo $vo

--- a/lib/AdapterLdap.php
+++ b/lib/AdapterLdap.php
@@ -17,12 +17,12 @@ class sspmod_perun_AdapterLdap extends sspmod_perun_Adapter
 			$query .= "(eduPersonPrincipalNames=$uid)";
 		}
 
-		if ($empty($query)) {
+		if (empty($query)) {
 			return null;
 		}
 
 		$user = sspmod_perun_LdapConnector::searchForEntity("ou=People,dc=perun,dc=cesnet,dc=cz",
-			"(!$query)",
+			"(|$query)",
 			array("perunUserId", "displayName", "cn", "givenName", "sn", "preferredMail", "mail")
 		);
 

--- a/lib/AdapterLdap.php
+++ b/lib/AdapterLdap.php
@@ -9,12 +9,23 @@ class sspmod_perun_AdapterLdap extends sspmod_perun_Adapter
 {
 
 
-	public function getPerunUser($idpEntityId, $uid)
+	public function getPerunUser($idpEntityId, $uids)
 	{
+		# Build a LDAP query, we are searching for the user who has at least one of the uid
+		$query = '';
+                foreach ($uids as $uid) {
+			$query .= "(eduPersonPrincipalNames=$uid)";
+		}
+
+		if ($empty($query)) {
+			return null;
+		}
+
 		$user = sspmod_perun_LdapConnector::searchForEntity("ou=People,dc=perun,dc=cesnet,dc=cz",
-			"(eduPersonPrincipalNames=$uid)",
+			"(!$query)",
 			array("perunUserId", "displayName", "cn", "givenName", "sn", "preferredMail", "mail")
 		);
+
 		if (is_null($user)) {
 			return $user;
 		}

--- a/lib/AdapterRpc.php
+++ b/lib/AdapterRpc.php
@@ -9,32 +9,38 @@ class sspmod_perun_AdapterRpc extends sspmod_perun_Adapter
 {
 
 
-	public function getPerunUser($idpEntityId, $uid)
+	public function getPerunUser($idpEntityId, $uids)
 	{
-		try {
-			$user = sspmod_perun_RpcConnector::get('usersManager', 'getUserByExtSourceNameAndExtLogin', array(
-				'extSourceName' => $idpEntityId,
-				'extLogin' => $uid,
-			));
+		$user = null;
 
-			$name = '';
-			if (!empty($user['titleBefore'])) $name .= $user['titleBefore'].' ';
-			if (!empty($user['titleBefore'])) $name .= $user['firstName'].' ';
-			if (!empty($user['titleBefore'])) $name .= $user['middleName'].' ';
-			if (!empty($user['titleBefore'])) $name .= $user['lastName'];
-			if (!empty($user['titleBefore'])) $name .= ' '.$user['titleAfter'];
+		foreach ($uids as $uid) {
+			try {
+				$user = sspmod_perun_RpcConnector::get('usersManager', 'getUserByExtSourceNameAndExtLogin', array(
+					'extSourceName' => $idpEntityId,
+					'extLogin' => $uid,
+				));
 
-			return new sspmod_perun_model_User($user['id'], $name);
-		} catch (sspmod_perun_Exception $e) {
-			if ($e->getName() === 'UserExtSourceNotExistsException') {
-				return null;
-			} else if ($e->getName() === 'ExtSourceNotExistsException') {
-				// Because use of original/source entityID as extSourceName
-				return null;
-			} else {
-				throw $e;
+				$name = '';
+				if (!empty($user['titleBefore'])) $name .= $user['titleBefore'].' ';
+				if (!empty($user['titleBefore'])) $name .= $user['firstName'].' ';
+				if (!empty($user['titleBefore'])) $name .= $user['middleName'].' ';
+				if (!empty($user['titleBefore'])) $name .= $user['lastName'];
+				if (!empty($user['titleBefore'])) $name .= ' '.$user['titleAfter'];
+
+				return new sspmod_perun_model_User($user['id'], $name);
+			} catch (sspmod_perun_Exception $e) {
+				if ($e->getName() === 'UserExtSourceNotExistsException') {
+					continue;
+				} else if ($e->getName() === 'ExtSourceNotExistsException') {
+					// Because use of original/source entityID as extSourceName
+					continue;
+				} else {
+					throw $e;
+				}
 			}
 		}
+
+		return $user;
 	}
 
 


### PR DESCRIPTION
Before deploying this code, the configuration of the PerunIdentity module for idp in saml20-idp-hosted.php must be changed. New configuration option uidsAttr must be defined. It contains array of user ID attribute names, e.g. 'uidsAttr' => array('eduPersonUniqueId', 'eduPersonPrincipalName', 'eduPersonTargetedIDString', 'nameid'),