### PR TITLE
Added filtering for AuthnContextClassRef

### DIFF
--- a/config-templates/module_perun.php
+++ b/config-templates/module_perun.php
@@ -39,4 +39,10 @@ $config = array(
 	 */
 	//'disco.disableWhitelisting' => true,
 
+	/**
+	 * Specify prefix for filtering AuthnContextClassRef
+	 * All AuthnContextClassRef values starts with this prefix will be removed before the request will be send to IdP
+	 */
+	'disco.removeAuthnContextClassRefPrefix' => 'urn:cesnet:proxyidp:',
+
 );


### PR DESCRIPTION
* The AuthnContextClassRef is now filtered before the request is send to idp and every AuthnContextClassRef values which start with prefix from configuration will be removed