### PR TITLE
Bunch of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# IntelliJ project files
+.idea
+*.iml
+out
+gen


### PR DESCRIPTION
* added .gitignore
* Added check if field 'query' exists in $returnURL. (Old code generated LOG messages if it was not set)
* Added check if field 'AuthID' exists in $query. (Old code generated LOG messages if it was not set)
* Added check if $state is not null. (Old code generated LOG messages if it was not set)
* Added check if field 'SPmetadata' exists in $state. (Old code generated LOG messages if it was not set)
* Added check if field 'query' exists in $returnURL. (Old code generated LOG messages if it was not set)