### PR TITLE
Fix perun attributes mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to this project will be documented in this file.
  ## [Unreleased]
  [Added]
  - List of services is displayed as JSON if parameter 'output=json' is set in URL
- 
+
  [Fixed]
  - Fixed the problem where LDAP calls RPC method in PerunIdentity filter
+ - Fixed assignation of one Perun attribute to multiple SP attributes
  
  ## [v2.1.0]
  [Added]

--- a/lib/Auth/Process/PerunAttributes.php
+++ b/lib/Auth/Process/PerunAttributes.php
@@ -51,7 +51,7 @@ class sspmod_perun_Auth_Process_PerunAttributes extends SimpleSAML_Auth_Processi
 		} else {
 			throw new SimpleSAML_Error_Exception("perun:PerunAttributes: " .
 					"missing mandatory field 'perun.user' in request." .
-					"Hint: Did you configured PerunIdentity filter before this filter?"
+					"Hint: Have you configured PerunIdentity filter before this filter?"
 			);
 		}
 
@@ -77,7 +77,7 @@ class sspmod_perun_Auth_Process_PerunAttributes extends SimpleSAML_Auth_Processi
 			}
 
 			SimpleSAML\Logger::debug("perun:PerunAttributes: perun attribute $attrName was fetched. " .
-					"Value ".implode(",", $value)." is being setted to ssp attribute $sspAttr");
+					"Value ".implode(",", $value)." is being set to ssp attribute $sspAttr");
 
 			$request['Attributes'][$sspAttr] = $value;
 		}

--- a/lib/Auth/Process/PerunAttributes.php
+++ b/lib/Auth/Process/PerunAttributes.php
@@ -63,6 +63,7 @@ class sspmod_perun_Auth_Process_PerunAttributes extends SimpleSAML_Auth_Processi
 
 			$sspAttr = $this->attrMap[$attrName];
 
+			// convert $attrValue into array
 			if (is_null($attrValue)) {
 				$value = array();
 			} else if (is_string($attrValue)) {
@@ -76,10 +77,24 @@ class sspmod_perun_Auth_Process_PerunAttributes extends SimpleSAML_Auth_Processi
 				"Attribute name: $attrName, Supported types: null, string, array, associative array.");
 			}
 
-			SimpleSAML\Logger::debug("perun:PerunAttributes: perun attribute $attrName was fetched. " .
-					"Value ".implode(",", $value)." is being set to ssp attribute $sspAttr");
+			// convert $sspAttr into array
+			if (is_string($sspAttr)) {
+				$attrArray = array($sspAttr);
+			} else if (is_array($sspAttr)) {
+				$attrArray = $sspAttr;
+			} else {
+				throw new SimpleSAML_Error_Exception("sspmod_perun_Auth_Process_PerunAttributes - Unsupported attribute type. ".
+						"Attribute \$attrName, Supported types: string, array.");
+			}
 
-			$request['Attributes'][$sspAttr] = $value;
+			SimpleSAML\Logger::debug("perun:PerunAttributes: perun attribute $attrName was fetched. " .
+					"Value " . implode(",", $value) . " is being set to ssp attribute " . implode(",", $attrArray));
+
+			// write $value to all SP attributes
+			foreach ($attrArray as $attribute) {
+				$request['Attributes'][$attribute] = $value;
+			}
+
 		}
 
 	}


### PR DESCRIPTION
PerunAttributes filter did not allow assigning of one LDAP reply into multiple attributes on SP side. This is now handled by implicitly converting target attributes into array (even if there is only one) and changing the subsequent logic to handle arrays.