### PR TITLE
Fixed the bug in 'getEntitylesAttribute' function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
  
 ## [Unreleased]
+#### Fixed
+- Fixed the bug in 'getEntitylesAttribute' function to return correct value of Entityless attribute 
 
 ## [v3.3.0]
 #### Added

--- a/lib/Adapter.php
+++ b/lib/Adapter.php
@@ -99,7 +99,7 @@ abstract class Adapter
 
     /**
      * @param string $attrName
-     * @return array of all entityless attributes with attrName (for all namespaces of same attribute).
+     * @return map of all entityless attributes with attrName (for all namespaces of same attribute).
      */
     abstract public function getEntitylessAttribute($attrName);
 

--- a/lib/AdapterRpc.php
+++ b/lib/AdapterRpc.php
@@ -250,13 +250,25 @@ class AdapterRpc extends Adapter
 
     public function getEntitylessAttribute($attrName)
     {
-        $perunAttrs = $this->connector->get('attributesManager', 'getEntitylessAttributes', [
+        $attributes = [];
+
+        $perunAttrValues = $this->connector->get('attributesManager', 'getEntitylessAttributes', [
             'attrName' => $attrName,
         ]);
 
-        $attributes = [];
-        foreach ($perunAttrs as $perunAttr) {
-            $attributes[key($perunAttr['value'])] = $perunAttr['value'][key($perunAttr['value'])];
+        if (!isset($perunAttrValues[0]['id'])) {
+            return $attributes;
+        }
+        $attrId = $perunAttrValues[0]['id'];
+
+        $perunAttrKeys = $this->connector->get('attributesManager', 'getEntitylessKeys', [
+            'attributeDefinition' => $attrId,
+        ]);
+
+        for ($i = 0, $iMax = count($perunAttrKeys); $i < $iMax; $i++) {
+            $key = $perunAttrKeys[$i];
+            $value = $perunAttrValues[$i];
+            $attributes[$key] = $value;
         }
 
         return $attributes;

--- a/lib/Auth/Process/ForceAup.php
+++ b/lib/Auth/Process/ForceAup.php
@@ -151,7 +151,12 @@ class ForceAup extends \SimpleSAML\Auth\ProcessingFilter
                 return;
             }
 
-            $perunAups = $this->adapter->getEntitylessAttribute($this->perunAupsAttr);
+            $perunAupsAttr = $this->adapter->getEntitylessAttribute($this->perunAupsAttr);
+
+            $perunAups = [];
+            foreach ($perunAupsAttr as $key => $attr) {
+                $perunAups[$key] = $attr['value'];
+            }
 
             $userAups = $this->adapter->getUserAttributes(
                 $user,


### PR DESCRIPTION
* Fixed the bug in 'getEntitylesAttribute' function to return correct value of Entityless attribute. Before this fix the method was usable only for EntitylessAttribute with type LinkedHashMap. Now the function is usable for all types of PerunAttributes.