### PR TITLE
Fixed the bug in getting new aups to sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 - Fixed the bug in 'getEntitylesAttribute' function to return correct value of Entityless attribute 
+- Fixed the bug in getting new aups to sign
 
 ## [v3.3.0]
 #### Added

--- a/lib/Auth/Process/ForceAup.php
+++ b/lib/Auth/Process/ForceAup.php
@@ -181,7 +181,7 @@ class ForceAup extends \SimpleSAML\Auth\ProcessingFilter
                         $userLatestAup = $this->getLatestAup($userAupsList);
 
                         if ($latest_aup->date === $userLatestAup->date) {
-                            break;
+                            continue;
                         }
                     }
                     $newAups[$requiredAup] = $latest_aup;
@@ -198,7 +198,7 @@ class ForceAup extends \SimpleSAML\Auth\ProcessingFilter
                         $userLatestAup = $this->getLatestAup($userAupsList);
 
                         if ($latest_aup->date === $userLatestAup->date) {
-                            break;
+                            continue;
                         }
                     }
 


### PR DESCRIPTION
* Fixed the bug in getting new aups to sign. The problem was that method stop getting newAup, when user has approved one of required Aup.