### PR TITLE
Changes in getting configuration in PerunEntitlement.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 #### Added
 - Added facility capabilities to PerunEntitlement
 
+#### Changed
+- Use object `Configuration` for getting base module configuration
+
 #### Fixed
 - Fixed the width of showed tagged idps in case the count of idps is equal to (x * 3) + 1
 

--- a/lib/Auth/Process/PerunEntitlement.php
+++ b/lib/Auth/Process/PerunEntitlement.php
@@ -34,7 +34,6 @@ class PerunEntitlement extends ProcessingFilter
     private $entitlementPrefix;
     private $entitlementAuthority;
     private $groupNameAARC;
-    private $interface;
     private $adapter;
 
     public function __construct($config, $reserved)
@@ -62,12 +61,12 @@ class PerunEntitlement extends ProcessingFilter
             $this->groupNameAARC ? Configuration::REQUIRED_OPTION : ''
         );
 
-        $this->interface = $configuration->getValueValidate(
+        $interface = $configuration->getValueValidate(
             self::INTERFACE_PROPNAME,
             [Adapter::RPC, Adapter::LDAP],
             Adapter::RPC
         );
-        $this->adapter = Adapter::getInstance($this->interface);
+        $this->adapter = Adapter::getInstance($interface);
     }
 
     public function process(&$request)

--- a/lib/Auth/Process/PerunEntitlement.php
+++ b/lib/Auth/Process/PerunEntitlement.php
@@ -40,7 +40,7 @@ class PerunEntitlement extends ProcessingFilter
     public function __construct($config, $reserved)
     {
         parent::__construct($config, $reserved);
-        $conf = Configuration::getConfig(self::CONFIG_FILE_NAME);
+        $modulePerunConfiguration = Configuration::getConfig(self::CONFIG_FILE_NAME);
         assert('is_array($config)');
 
         if (!isset($config[self::EDU_PERSON_ENTITLEMENT])) {
@@ -63,9 +63,9 @@ class PerunEntitlement extends ProcessingFilter
         }
         $this->forwardedEduPersonEntitlement = $config[self::FORWARDED_EDU_PERSON_ENTITLEMENT];
 
-        $this->entitlementPrefix = $conf->getString(self::ENTITLEMENTPREFIX_ATTR, '');
-        $this->entitlementAuthority = $conf->getString(self::ENTITLEMENTAUTHORITY_ATTR, '');
-        $this->groupNameAARC = $conf->getBoolean(self::GROUPNAMEAARC_ATTR, false);
+        $this->entitlementPrefix = $modulePerunConfiguration->getString(self::ENTITLEMENTPREFIX_ATTR, '');
+        $this->entitlementAuthority = $modulePerunConfiguration->getString(self::ENTITLEMENTAUTHORITY_ATTR, '');
+        $this->groupNameAARC = $modulePerunConfiguration->getBoolean(self::GROUPNAMEAARC_ATTR, false);
 
         if ($this->groupNameAARC && (empty($this->entitlementAuthority) || empty($this->entitlementPrefix))) {
             throw new Exception(


### PR DESCRIPTION
* Rename property $conf to $modulePerunConfiguration
* Use object `Configuration` for getting base module configuration
* Remove unnecessary private option
