### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "cesnet/simplesamlphp-module-perun",
     "description": "Module which allows SSP to communicate with Perun IAM https://perun.cesnet.cz",
     "type": "simplesamlphp-module",
-    "version": "3.9.0-dev",
     "keywords": ["Perun", "perun", "simplesamlphp"],
     "license": "BSD-2-Clause",
     "authors": [


### PR DESCRIPTION
Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.

https://getcomposer.org/doc/04-schema.md#version