### PR TITLE
When user displays ext. list, hide previous selection if it is tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 #### Changed
 - Changed the way of getting attribute names for interfaces: through internal attribute names in perun_attributes.php config
 - Return sorted eduPersonEntitlement
+- Don't show previous selection when user show all entries on the discovery page
 
 ## [v3.9.0]
 #### Added

--- a/lib/Disco.php
+++ b/lib/Disco.php
@@ -446,9 +446,14 @@ class Disco extends PowerIdPDisco
         return $html;
     }
 
-    public static function getOr()
+    public static function getOr($id = NULL)
     {
-        $or = '<div class="hrline">';
+        $or = '';
+        if (!is_null($id)) {
+            $or .= '<div class="hrline" id="' . $id . '">';
+        } else {
+            $or .= '<div class="hrline">';
+        }
         $or .= '	<span>or</span>';
         $or .= '</div>';
         return $or;
@@ -514,6 +519,9 @@ class Disco extends PowerIdPDisco
         $script = '<script type="text/javascript">
          $(document).ready(function() {
              $("#showEntries").click(function() {
+                 $("#last-used-idp").hide();
+                 $("#last-used-idp-desc").hide();
+                 $("#last-used-idp-or").hide();
                  $("#entries").show();
                  $("#showEntries").hide();
              });

--- a/themes/perun/perun/disco-tpl.php
+++ b/themes/perun/perun/disco-tpl.php
@@ -123,12 +123,12 @@ if ($this->isAddInstitutionApp()) {
 
     if (!$warningIsOn || $warningType === WARNING_TYPE_INFO || $warningType === WARNING_TYPE_WARNING) {
         if (!empty($this->getPreferredIdp())) {
-            echo '<p class="descriptionp">' . $this->t('{perun:disco:previous_selection}') . '</p>';
+            echo '<p class="descriptionp" id="last-used-idp-desc">' . $this->t('{perun:disco:previous_selection}') . '</p>';
             echo '<div id="last-used-idp" class="metalist list-group">';
             echo Disco::showEntry($this, $this->getPreferredIdp(), true);
             echo '</div>';
 
-            echo Disco::getOr();
+            echo Disco::getOr("last-used-idp-or");
 
             echo '<a id="showEntries" class="metaentry btn btn-block btn-default btn-lg" href="#">' .
                  $this->t('{perun:disco:sign_with_other_institution}') . '</a>' ;


### PR DESCRIPTION
- when the user clicks on the discovery page to show all entries, we do not
want to display the previous selection