### PR TITLE
optionally keep indexes of endpoints in metadata

### DIFF
--- a/lib/MetadataToPerun.php
+++ b/lib/MetadataToPerun.php
@@ -99,7 +99,7 @@ class MetadataToPerun
         $this->addXmlAttributes($metadata, $facility);
 
         foreach ($this->transformers as $transformer) {
-            $attrs = array_filter(array_intersect_key($facility, array_flip($transformer['attributes'])));
+            $attrs = array_intersect_key($facility, array_flip($transformer['attributes']));
             if (!empty($attrs)) {
                 $newAttrs = $transformer['instance']->transform($attrs);
                 $facility = array_merge($facility, $newAttrs);

--- a/lib/transformers/EndpointIndexMap.php
+++ b/lib/transformers/EndpointIndexMap.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @author Pavel Brousek <brousek@ics.muni.cz>
+ */
+
+namespace SimpleSAML\Module\perun\transformers;
+
+use SimpleSAML\Module\perun\AttributeTransformer;
+
+/**
+ * Get map of binding to comma separated list of endpoints with the option to keep original indexes.
+ */
+class EndpointIndexMap extends AttributeTransformer
+{
+    const MAPLIST_SEPARATOR = ',';
+
+    const BINDING_PREFIX = 'urn:oasis:names:tc:SAML:2.0:bindings:';
+
+    private $defaultBinding;
+
+    private $fullNames;
+
+    /**
+     * @override
+     */
+    public function __construct(\SimpleSAML\Configuration $config)
+    {
+        $this->defaultBinding = $config->getString('defaultBinding');
+        $this->fullNames = !$config->getBoolean('shortNames', false);
+    }
+
+    /**
+     * @override
+     */
+    public function transform(array $attributes)
+    {
+        if (count($attributes) !== 2) {
+            throw new \Exception(
+                'Invalid configuration of EndpointIndexMap transformer, exactly 2 input attributes exptected'
+            );
+        }
+        list($endpoints, $keepIndexes) = array_values($attributes);
+        $names = array_keys($attributes);
+        $attributeName = $names[0];
+        if (is_bool($endpoints)) {
+            $tmp = $keepIndexes;
+            $keepIndexes = $endpoints;
+            $endpoints = $tmp;
+            $attributeName = $names[1];
+        }
+        if (empty($endpoints)) {
+            $result = null;
+        } else {
+            if (!is_array($endpoints)) {
+                $endpoints = [['Location' => $endpoints]];
+            }
+            $result = [];
+            foreach ($endpoints as $endpoint) {
+                $binding = $endpoint['Binding'] ?: $this->defaultBinding;
+                if (!$this->fullNames) {
+                    $binding = str_replace(self::BINDING_PREFIX, '', $binding);
+                }
+                if (!isset($result[$binding])) {
+                    $result[$binding] = [];
+                }
+
+                $result[$binding][$endpoint['index'] - 1] = $endpoint['Location'];
+            }
+            if ($keepIndexes) {
+                $result = array_map(function ($endpoints) {
+                    $e = [];
+                    for ($i = 0; $i <= max(array_keys($endpoints)); $i++) {
+                        $e[] = isset($endpoints[$i]) ? $endpoints[$i] : '';
+                    }
+                    return implode(self::MAPLIST_SEPARATOR, $e);
+                }, $result);
+            } else {
+                $result = array_map(function ($endpoints) {
+                    return implode(self::MAPLIST_SEPARATOR, $endpoints);
+                }, $result);
+            }
+        }
+        return [
+            $attributeName => $result,
+        ];
+    }
+
+    /**
+     * @override
+     */
+    public function getDescription(array $attributes)
+    {
+        $descriptions = array_values($attributes);
+        $names = array_keys($attributes);
+        return [
+            $names[0] => sprintf('comma-separated lists of Locations per Bindings from (%s)', $descriptions[0]),
+            $names[1] => '',
+        ];
+    }
+}

--- a/lib/transformers/EndpointMapToArray.php
+++ b/lib/transformers/EndpointMapToArray.php
@@ -17,7 +17,7 @@ class EndpointMapToArray extends AttributeTransformer
 
     const BINDING_PREFIX = 'urn:oasis:names:tc:SAML:2.0:bindings:';
 
-    const INDEX_MIN = 0;
+    const INDEX_MIN = 1;
 
     private $defaultBinding;
 


### PR DESCRIPTION
Allow keeping endpoints at the same indexes as in metadata, for SPs which rely on the indexes instead of full addresses.
Example config (after merge):

```
// ...
'flatfile2internal' => [
        // ...
        'usesIndexes' => 'entityid',
],
'importTransformers' => [
        [
            'class' => '\\SimpleSAML\\Module\\perun\\transformers\\AttributeAlter',
            'attributes' => ['usesIndexes'],
            'config' => [
                'pattern' => '/^https:\/\/sp\.tshhosting\.com\/shibboleth$/',
                'replacement' => '',
            ],
        ],
        [
            'class' => '\\SimpleSAML\\Module\\perun\\transformers\\LogicalNot',
            'attributes' => ['usesIndexes'],
            'config' => [],
        ],
        [
            'class' => '\\SimpleSAML\\Module\\perun\\transformers\\EndpointIndexMap',
            'attributes' => ['assertionConsumerService', 'usesIndexes'],
            'config' => ['defaultBinding' => 'HTTP-POST', 'shortNames' => true],
        ],
        // ...
],
```