### PR TITLE
feat: entityId in entitlement filters can be now set in config

### DIFF
--- a/lib/Auth/Process/PerunEntitlementExtended.php
+++ b/lib/Auth/Process/PerunEntitlementExtended.php
@@ -28,6 +28,7 @@ class PerunEntitlementExtended extends ProcessingFilter
     const ENTITLEMENTAUTHORITY_ATTR = 'entitlementAuthority';
     const GROUPNAMEAARC_ATTR = 'groupNameAARC';
     const INTERFACE_PROPNAME = 'interface';
+    const ENTITY_ID = 'entityID';
 
     private $outputAttrName;
     private $releaseForwardedEntitlement;
@@ -36,6 +37,7 @@ class PerunEntitlementExtended extends ProcessingFilter
     private $entitlementAuthority;
     private $groupNameAARC;
     private $adapter;
+    private $entityId;
 
     public function __construct($config, $reserved)
     {
@@ -62,6 +64,8 @@ class PerunEntitlementExtended extends ProcessingFilter
             $this->groupNameAARC ? Configuration::REQUIRED_OPTION : ''
         );
 
+        $this->entityId = $modulePerunConfiguration->getString(self::ENTITY_ID, null);
+
         $interface = $configuration->getValueValidate(
             self::INTERFACE_PROPNAME,
             [Adapter::RPC, Adapter::LDAP],
@@ -76,6 +80,10 @@ class PerunEntitlementExtended extends ProcessingFilter
         $capabilities = [];
         $forwardedEduPersonEntitlement = [];
 
+        if ($this->entityId === null) {
+            $this->entityId = EntitlementUtils::getSpEntityId($request);
+        }
+
         if (isset($request['perun']['groups'])) {
             $eduPersonEntitlementExtended = $this->getEduPersonEntitlementExtended($request);
 
@@ -83,7 +91,8 @@ class PerunEntitlementExtended extends ProcessingFilter
                 $request,
                 $this->adapter,
                 $this->entitlementPrefix,
-                $this->entitlementAuthority
+                $this->entitlementAuthority,
+                $this->entityId
             );
         } else {
             Logger::debug(

--- a/lib/EntitlementUtils.php
+++ b/lib/EntitlementUtils.php
@@ -53,13 +53,12 @@ class EntitlementUtils
         return $result;
     }
 
-    public static function getCapabilities(&$request, $adapter, $prefix, $authority)
+    public static function getCapabilities(&$request, $adapter, $prefix, $authority, $spEntityId)
     {
         $resourceCapabilities = [];
         $facilityCapabilities = [];
         $capabilitiesResult = [];
 
-        $spEntityId = self::getSpEntityId($request);
         try {
             $resourceCapabilities = $adapter->getResourceCapabilities($spEntityId, $request['perun']['groups']);
             $facilityCapabilities = $adapter->getFacilityCapabilities($spEntityId);
@@ -142,7 +141,7 @@ class EntitlementUtils
             EntitlementUtils::encodeName($groupName) . '#' . $authority;
     }
 
-    private static function getSpEntityId(&$request)
+    public static function getSpEntityId(&$request)
     {
         if (isset($request['SPMetadata']['entityid'])) {
             return $request['SPMetadata']['entityid'];


### PR DESCRIPTION
PerunEntitlement and PerunEntitlementExtended filters now read entityID from config. If entityID isn't set in config, filters will read it from request same as before.