### PR TITLE
fix: revert change to INDEX_MIN in EndpointMapToArray

### DIFF
--- a/lib/transformers/EndpointMapToArray.php
+++ b/lib/transformers/EndpointMapToArray.php
@@ -17,7 +17,7 @@ class EndpointMapToArray extends AttributeTransformer
 
     const BINDING_PREFIX = 'urn:oasis:names:tc:SAML:2.0:bindings:';
 
-    const INDEX_MIN = 1;
+    const INDEX_MIN = 0;
 
     private $defaultBinding;
 


### PR DESCRIPTION
the correct INDEX_MIN is zero because it is an unsignedShort in the [SAML metadata spec](https://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf) and also in eduGAIN some SPs use `0` as the first index, so it needs to be supported