### PR TITLE
fix: detailed endpoint format when spaced in EndpointMapToArray

### DIFF
--- a/lib/transformers/EndpointMapToArray.php
+++ b/lib/transformers/EndpointMapToArray.php
@@ -68,7 +68,8 @@ class EndpointMapToArray extends AttributeTransformer
         // if all endpoints use the default binding and there are no spaces
         if (count($endpointMap) === 1 && isset($endpointMap[$this->defaultBinding])
             && strpos(
-                $endpointMap[$this->defaultBinding], self::MAPLIST_SEPARATOR . self::MAPLIST_SEPARATOR
+                $endpointMap[$this->defaultBinding],
+                self::MAPLIST_SEPARATOR . self::MAPLIST_SEPARATOR
             ) === false) {
             $result = explode(self::MAPLIST_SEPARATOR, $endpointMap[$this->defaultBinding]);
             return count($result) === 1 ? $result[0] : $result;

--- a/lib/transformers/EndpointMapToArray.php
+++ b/lib/transformers/EndpointMapToArray.php
@@ -67,7 +67,9 @@ class EndpointMapToArray extends AttributeTransformer
 
         // if all endpoints use the default binding and there are no spaces
         if (count($endpointMap) === 1 && isset($endpointMap[$this->defaultBinding])
-            && strpos($endpointMap[$this->defaultBinding], self::MAPLIST_SEPARATOR . self::MAPLIST_SEPARATOR) === false) {
+            && strpos(
+                $endpointMap[$this->defaultBinding], self::MAPLIST_SEPARATOR . self::MAPLIST_SEPARATOR
+            ) === false) {
             $result = explode(self::MAPLIST_SEPARATOR, $endpointMap[$this->defaultBinding]);
             return count($result) === 1 ? $result[0] : $result;
         }

--- a/lib/transformers/EndpointMapToArray.php
+++ b/lib/transformers/EndpointMapToArray.php
@@ -65,8 +65,9 @@ class EndpointMapToArray extends AttributeTransformer
         }
         $endpointMap = $fullBindingNames;
 
-        // if all endpoints use the default binding
-        if (count($endpointMap) === 1 && isset($endpointMap[$this->defaultBinding])) {
+        // if all endpoints use the default binding and there are no spaces
+        if (count($endpointMap) === 1 && isset($endpointMap[$this->defaultBinding])
+            && strpos($endpointMap[$this->defaultBinding], self::MAPLIST_SEPARATOR . self::MAPLIST_SEPARATOR) === false) {
             $result = explode(self::MAPLIST_SEPARATOR, $endpointMap[$this->defaultBinding]);
             return count($result) === 1 ? $result[0] : $result;
         }


### PR DESCRIPTION
when there are spaces in the endpoint list, use the detailed format with index numbers instead of the simple array

The spaces imply that keepIndexes was used when importing, but it is not 100% accurate. To be precise, it would need a new facility attribute, which seems too much for just 1 SP in the whole eduGAIN.