### PR TITLE
fix: 🐛 Added missing ext-intl to the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-iconv": "*",
+        "ext-intl": "*",
         "web-token/jwt-key-mgmt": "^2.2",
         "web-token/jwt-signature": "^2.2",
         "web-token/jwt-signature-algorithm-rsa": "^2.2",


### PR DESCRIPTION
Missing extension caused calls to the function
transliteration_transliterate be evaluated as call to an undefined
function