### PR TITLE
chore: add missing extensions to CI workflow

### DIFF
--- a/.github/workflows/build_and_check.yml
+++ b/.github/workflows/build_and_check.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           php_version: ${{ matrix.php-version }}
           version: 2
-          php_extensions: json
+          php_extensions: curl json openssl iconv intl
       - name: Run easy coding standard
         run: vendor/bin/ecs check
   release:


### PR DESCRIPTION
Added missing extensions to the build_and_check workflow