### PR TITLE
fix: 🐛 Fix wrong variable names in getFacilityByXY methods

### DIFF
--- a/lib/AdapterLdap.php
+++ b/lib/AdapterLdap.php
@@ -287,8 +287,11 @@ class AdapterLdap extends Adapter
     public function getFacilityByEntityId($spEntityId, $entityIdAttr = 'perunFacilityAttr_entityID')
     {
         $attrName = AttributeUtils::getLdapAttrName($entityIdAttr);
-        if (empty($attributeName)) {
-            throw new Exception("No attribute configuration in LDAP found for attribute ${entityIdAttr}");
+        if (empty($attrName)) {
+            $attrName = 'entityID';
+            Logger::warning(
+                "No attribute configuration in LDAP found for attribute ${entityIdAttr}, using ${attrName} as fallback value"
+            );
         }
         $ldapResult = $this->connector->searchForEntity(
             $this->ldapBase,
@@ -301,21 +304,22 @@ class AdapterLdap extends Adapter
             return null;
         }
 
-        $facility = new Facility(
+        return new Facility(
             $ldapResult[self::PERUN_FACILITY_ID][0],
             $ldapResult[self::CN][0],
             $ldapResult[self::DESCRIPTION][0],
             $spEntityId
         );
-
-        return $facility;
     }
 
     public function getFacilityByClientId($clientId, $clientIdAttr = 'perunFacilityAttr_OIDCClientID')
     {
         $attrName = AttributeUtils::getLdapAttrName($clientIdAttr);
-        if (empty($attributeName)) {
-            throw new Exception("No attribute configuration in LDAP found for attribute ${clientIdAttr}");
+        if (empty($attrName)) {
+            $attrName = 'OIDCClientID';
+            Logger::warning(
+                "No attribute configuration in LDAP found for attribute ${clientIdAttr}, using ${attrName} as fallback value"
+            );
         }
         $ldapResult = $this->connector->searchForEntity(
             $this->ldapBase,
@@ -328,14 +332,12 @@ class AdapterLdap extends Adapter
             return null;
         }
 
-        $facility = new Facility(
+        return new Facility(
             $ldapResult[self::PERUN_FACILITY_ID][0],
             $ldapResult[self::CN][0],
             $ldapResult[self::DESCRIPTION][0],
             $clientId
         );
-
-        return $facility;
     }
 
     public function getEntitylessAttribute($attrName)

--- a/lib/AdapterRpc.php
+++ b/lib/AdapterRpc.php
@@ -371,12 +371,15 @@ class AdapterRpc extends Adapter
 
     public function getFacilityByEntityId($spEntityId, $entityIdAttr = 'perunFacilityAttr_entityID')
     {
-        $attributeName = AttributeUtils::getRpcAttrName($entityIdAttr);
-        if (empty($attributeName)) {
-            throw new Exception("No attribute configuration in RPC found for attribute ${entityIdAttr}");
+        $attrName = AttributeUtils::getRpcAttrName($entityIdAttr);
+        if (empty($attrName)) {
+            $attrName = 'urn:perun:facility:attribute-def:def:entityID';
+            Logger::warning(
+                "No attribute configuration in RPC found for attribute ${entityIdAttr}, using ${attrName} as fallback value"
+            );
         }
         $perunAttr = $this->connector->get('facilitiesManager', 'getFacilitiesByAttribute', [
-            'attributeName' => $attributeName,
+            'attributeName' => $attrName,
             'attributeValue' => $spEntityId,
         ]);
 
@@ -397,12 +400,15 @@ class AdapterRpc extends Adapter
 
     public function getFacilityByClientId($clientId, $clientIdAttr = 'perunFacilityAttr_OIDCClientID')
     {
-        $attributeName = AttributeUtils::getRpcAttrName($clientIdAttr);
-        if (empty($attributeName)) {
-            throw new Exception("No attribute configuration in RPC found for attribute ${clientIdAttr}");
+        $attrName = AttributeUtils::getRpcAttrName($clientIdAttr);
+        if (empty($attrName)) {
+            $attrName = 'urn:perun:facility:attribute-def:def:OIDCClientID';
+            Logger::warning(
+                "No attribute configuration in RPC found for attribute ${clientIdAttr}, using ${attrName} as fallback value"
+            );
         }
         $perunAttr = $this->connector->get('facilitiesManager', 'getFacilitiesByAttribute', [
-            'attributeName' => $attributeName,
+            'attributeName' => $attrName,
             'attributeValue' => $clientId,
         ]);
 


### PR DESCRIPTION
Use correct name of the variable, otherwise it will always throw an
exception. Also use fallback value instead of throwing an exception.