### PR TITLE
fix: 🐛 Fix JSON in perun dictionary

### DIFF
--- a/dictionaries/perun.definition.json
+++ b/dictionaries/perun.definition.json
@@ -111,7 +111,6 @@
     "en": "Proceed to approval of the AUP",
     "cs": "Pokračovat na potvrzení souhlasu s AUP"
   },
-  ,
   "sp_authorize_403_header": {
     "en": "Unauthorized",
     "cs": "Přístup zamítnut"


### PR DESCRIPTION
Invalid JSON prevented dictionary to be loaded, which resulted in most
of the texts being untranslated.