### PR TITLE
feat(forceaup): new option entityID, fix required checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,9 @@
     "config": {
         "platform": {
             "php": "7.4"
+        },
+        "allow-plugins": {
+            "simplesamlphp/composer-module-installer": true
         }
     },
     "require": {


### PR DESCRIPTION
perunFacilityReqAupsAttr and perunFacilityVoShortNamesAttr have been required, but it was not checked. Now missing either of these options will throw an exception.