### PR TITLE
fix: do not use object as array in getResourceCapabilities

### DIFF
--- a/lib/AdapterRpc.php
+++ b/lib/AdapterRpc.php
@@ -707,7 +707,7 @@ class AdapterRpc extends Adapter
                 continue;
             }
             $resourceCapabilities = $this->connector->get('attributesManager', 'getAttribute', [
-                'resource' => $resource['id'],
+                'resource' => $resource->getId(),
                 'attributeName' => 'urn:perun:resource:attribute-def:def:capabilities',
             ]);
 
@@ -720,7 +720,7 @@ class AdapterRpc extends Adapter
             $resourceCapabilities = $resourceCapabilities['value'];
 
             $resourceGroups = $this->connector->get('resourcesManager', 'getAssignedGroups', [
-                'resource' => $resource['id'],
+                'resource' => $resource->getId(),
             ]);
 
             if (empty($resourceGroups)) {


### PR DESCRIPTION
introduced in 009160adf66c137d1c35b04a89abf29d90140f18